### PR TITLE
chore: localize docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+*.db
+.venv/
+.env.local
+frontend/node_modules/
+frontend/dist/

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""LiteHIS 后端应用包入口，便于外部导入。"""
+
+from .main import app, create_application
+
+__all__ = ["app", "create_application"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter
+
+from .appointments import router as appointments_router
+from .dashboard import router as dashboard_router
+from .departments import router as departments_router
+from .doctors import router as doctors_router
+from .patients import router as patients_router
+
+
+# 统一聚合子模块路由，便于在主应用中一次性挂载
+api_router = APIRouter()
+api_router.include_router(dashboard_router)
+api_router.include_router(departments_router)
+api_router.include_router(doctors_router)
+api_router.include_router(patients_router)
+api_router.include_router(appointments_router)
+
+__all__ = ["api_router"]

--- a/backend/app/api/appointments.py
+++ b/backend/app/api/appointments.py
@@ -1,0 +1,113 @@
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from ..database import get_session
+from ..models import (
+    Appointment,
+    AppointmentCreate,
+    AppointmentRead,
+    AppointmentStatus,
+    AppointmentUpdate,
+    Doctor,
+    Patient,
+)
+
+router = APIRouter(prefix="/appointments", tags=["appointments"])
+
+
+@router.get("/", response_model=List[AppointmentRead])
+def list_appointments(
+    *,
+    session: Session = Depends(get_session),
+    status_filter: Optional[AppointmentStatus] = Query(default=None, alias="status"),
+) -> List[AppointmentRead]:
+    """查询预约列表，可按状态筛选，并预加载患者与医生信息。"""
+
+    statement = select(Appointment).options(
+        selectinload(Appointment.patient), selectinload(Appointment.doctor)
+    )
+    if status_filter:
+        statement = statement.where(Appointment.status == status_filter)
+    statement = statement.order_by(Appointment.scheduled_time)
+    appointments = session.exec(statement).all()
+    return appointments
+
+
+@router.post("/", response_model=AppointmentRead, status_code=status.HTTP_201_CREATED)
+def create_appointment(
+    *, session: Session = Depends(get_session), appointment_in: AppointmentCreate
+) -> AppointmentRead:
+    """创建新的预约记录，保存前确认患者与医生均存在。"""
+
+    patient = session.get(Patient, appointment_in.patient_id)
+    if not patient:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Patient not found")
+
+    doctor = session.get(Doctor, appointment_in.doctor_id)
+    if not doctor:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Doctor not found")
+
+    appointment = Appointment(**appointment_in.model_dump())
+    session.add(appointment)
+    session.commit()
+    session.refresh(appointment)
+    # 手动附带外键关联对象，避免前端二次查询
+    appointment.patient = patient
+    appointment.doctor = doctor
+    return appointment
+
+
+@router.get("/{appointment_id}", response_model=AppointmentRead)
+def get_appointment(
+    *, session: Session = Depends(get_session), appointment_id: int
+) -> AppointmentRead:
+    """根据主键编号获取预约详情，包含关联的患者与医生。"""
+
+    appointment = session.exec(
+        select(Appointment)
+        .where(Appointment.id == appointment_id)
+        .options(selectinload(Appointment.patient), selectinload(Appointment.doctor))
+    ).first()
+    if not appointment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Appointment not found")
+    return appointment
+
+
+@router.patch("/{appointment_id}", response_model=AppointmentRead)
+def update_appointment(
+    *,
+    session: Session = Depends(get_session),
+    appointment_id: int,
+    appointment_update: AppointmentUpdate,
+) -> AppointmentRead:
+    """更新预约状态或时间，支持局部字段修改。"""
+
+    appointment = session.get(Appointment, appointment_id)
+    if not appointment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Appointment not found")
+
+    update_data = appointment_update.model_dump(exclude_unset=True)
+    if "doctor_id" in update_data and update_data["doctor_id"] is not None:
+        doctor = session.get(Doctor, update_data["doctor_id"])
+        if not doctor:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Doctor not found")
+    if "scheduled_time" in update_data and update_data["scheduled_time"]:
+        new_time = update_data["scheduled_time"]
+        if isinstance(new_time, datetime) and new_time < datetime.utcnow():
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Schedule must be in the future")
+
+    for key, value in update_data.items():
+        setattr(appointment, key, value)
+    session.add(appointment)
+    session.commit()
+    session.refresh(appointment)
+    appointment = session.exec(
+        select(Appointment)
+        .where(Appointment.id == appointment_id)
+        .options(selectinload(Appointment.patient), selectinload(Appointment.doctor))
+    ).first()
+    return appointment

--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -1,0 +1,46 @@
+from datetime import datetime, time
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from ..database import get_session
+from ..models import Appointment, DashboardSummary, Doctor, Patient
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+@router.get("/summary", response_model=DashboardSummary)
+def get_summary(*, session: Session = Depends(get_session)) -> DashboardSummary:
+    """统计仪表盘需要的关键指标，涵盖患者、医生与预约数量。"""
+
+    total_patients = session.exec(select(func.count(Patient.id))).one()
+    total_doctors = session.exec(select(func.count(Doctor.id))).one()
+
+    # 使用 UTC 日期范围统计当日预约量，保证跨时区兼容性
+    today = datetime.utcnow().date()
+    start_of_day = datetime.combine(today, time.min)
+    end_of_day = datetime.combine(today, time.max)
+
+    appointments_today = session.exec(
+        select(func.count(Appointment.id)).where(
+            Appointment.scheduled_time >= start_of_day,
+            Appointment.scheduled_time <= end_of_day,
+        )
+    ).one()
+
+    upcoming_appointments = session.exec(
+        select(func.count(Appointment.id)).where(Appointment.scheduled_time > datetime.utcnow())
+    ).one()
+
+    active_departments = session.exec(
+        select(func.count(func.distinct(Doctor.department_id))).where(Doctor.department_id.isnot(None))
+    ).one()
+
+    return DashboardSummary(
+        total_patients=total_patients or 0,
+        total_doctors=total_doctors or 0,
+        appointments_today=appointments_today or 0,
+        upcoming_appointments=upcoming_appointments or 0,
+        active_departments=active_departments or 0,
+    )

--- a/backend/app/api/departments.py
+++ b/backend/app/api/departments.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from ..database import get_session
+from ..models import Department, DepartmentCreate, DepartmentRead
+
+router = APIRouter(prefix="/departments", tags=["departments"])
+
+
+@router.get("/", response_model=List[DepartmentRead])
+def list_departments(*, session: Session = Depends(get_session)) -> List[DepartmentRead]:
+    """按名称排序返回全部科室。"""
+
+    departments = session.exec(select(Department).order_by(Department.name)).all()
+    return departments
+
+
+@router.post("/", response_model=DepartmentRead, status_code=status.HTTP_201_CREATED)
+def create_department(
+    *, session: Session = Depends(get_session), department_in: DepartmentCreate
+) -> DepartmentRead:
+    """新增科室时避免重名，若存在则返回冲突错误。"""
+
+    existing = session.exec(
+        select(Department).where(Department.name == department_in.name)
+    ).first()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Department already exists")
+
+    department = Department(**department_in.model_dump())
+    session.add(department)
+    session.commit()
+    session.refresh(department)
+    return department
+
+
+@router.get("/{department_id}", response_model=DepartmentRead)
+def get_department(*, session: Session = Depends(get_session), department_id: int) -> DepartmentRead:
+    """根据主键编号获取科室详情。"""
+
+    department = session.get(Department, department_id)
+    if not department:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Department not found")
+    return department

--- a/backend/app/api/doctors.py
+++ b/backend/app/api/doctors.py
@@ -1,0 +1,72 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from ..database import get_session
+from ..models import Department, Doctor, DoctorCreate, DoctorRead, DoctorUpdate
+
+router = APIRouter(prefix="/doctors", tags=["doctors"])
+
+
+@router.get("/", response_model=List[DoctorRead])
+def list_doctors(*, session: Session = Depends(get_session)) -> List[DoctorRead]:
+    """按姓名排序返回医生列表，并附带科室信息。"""
+
+    statement = select(Doctor).order_by(Doctor.full_name)
+    doctors = session.exec(statement).all()
+    return doctors
+
+
+@router.post("/", response_model=DoctorRead, status_code=status.HTTP_201_CREATED)
+def create_doctor(*, session: Session = Depends(get_session), doctor_in: DoctorCreate) -> DoctorRead:
+    """新增医生档案，如指定科室需提前校验是否存在。"""
+
+    if doctor_in.department_id is not None:
+        department = session.get(Department, doctor_in.department_id)
+        if not department:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Department not found")
+
+    doctor = Doctor(**doctor_in.model_dump())
+    session.add(doctor)
+    session.commit()
+    session.refresh(doctor)
+    return doctor
+
+
+@router.get("/{doctor_id}", response_model=DoctorRead)
+def get_doctor(*, session: Session = Depends(get_session), doctor_id: int) -> DoctorRead:
+    """根据主键编号查询医生详情。"""
+
+    doctor = session.get(Doctor, doctor_id)
+    if not doctor:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Doctor not found")
+    return doctor
+
+
+@router.patch("/{doctor_id}", response_model=DoctorRead)
+def update_doctor(
+    *,
+    session: Session = Depends(get_session),
+    doctor_id: int,
+    doctor_update: DoctorUpdate,
+) -> DoctorRead:
+    """更新医生档案信息，仅修改请求中提供的字段。"""
+
+    doctor = session.get(Doctor, doctor_id)
+    if not doctor:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Doctor not found")
+
+    update_data = doctor_update.model_dump(exclude_unset=True)
+    if "department_id" in update_data and update_data["department_id"] is not None:
+        # 当修改科室时，需要确认目标科室存在，避免脏数据
+        department = session.get(Department, update_data["department_id"])
+        if not department:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Department not found")
+
+    for key, value in update_data.items():
+        setattr(doctor, key, value)
+    session.add(doctor)
+    session.commit()
+    session.refresh(doctor)
+    return doctor

--- a/backend/app/api/patients.py
+++ b/backend/app/api/patients.py
@@ -1,0 +1,61 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from ..database import get_session
+from ..models import Patient, PatientCreate, PatientRead, PatientUpdate
+
+router = APIRouter(prefix="/patients", tags=["patients"])
+
+
+@router.get("/", response_model=List[PatientRead])
+def list_patients(*, session: Session = Depends(get_session)) -> List[PatientRead]:
+    """按创建时间倒序返回全部患者列表。"""
+
+    patients = session.exec(select(Patient).order_by(Patient.created_at.desc())).all()
+    return patients
+
+
+@router.post("/", response_model=PatientRead, status_code=status.HTTP_201_CREATED)
+def create_patient(*, session: Session = Depends(get_session), patient_in: PatientCreate) -> PatientRead:
+    """登记一位新患者，并返回持久化后的完整信息。"""
+
+    patient = Patient(**patient_in.model_dump())
+    session.add(patient)
+    session.commit()
+    session.refresh(patient)
+    return patient
+
+
+@router.get("/{patient_id}", response_model=PatientRead)
+def get_patient(*, session: Session = Depends(get_session), patient_id: int) -> PatientRead:
+    """根据主键编号获取患者详情。"""
+
+    patient = session.get(Patient, patient_id)
+    if not patient:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Patient not found")
+    return patient
+
+
+@router.patch("/{patient_id}", response_model=PatientRead)
+def update_patient(
+    *,
+    session: Session = Depends(get_session),
+    patient_id: int,
+    patient_update: PatientUpdate,
+) -> PatientRead:
+    """对患者记录做部分字段更新，仅覆盖请求中提供的内容。"""
+
+    patient = session.get(Patient, patient_id)
+    if not patient:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Patient not found")
+
+    update_data = patient_update.model_dump(exclude_unset=True)
+    # 遍历需要更新的键值对并写回实例
+    for key, value in update_data.items():
+        setattr(patient, key, value)
+    session.add(patient)
+    session.commit()
+    session.refresh(patient)
+    return patient

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,20 @@
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """应用配置，支持通过环境变量或 .env 文件覆盖。"""
+
+    # 应用名称会体现在 OpenAPI 文档与日志中
+    app_name: str = Field(default="LiteHIS")
+    # 默认使用 SQLite，可在部署时替换为国产数据库（如 openGauss、达梦等）
+    database_url: str = Field(default="sqlite:///./litehis.db")
+    # 允许跨域的前端地址列表，默认指向本地 Vite 服务
+    cors_origins: list[str] = Field(default_factory=lambda: ["http://localhost:5173"])
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+# 实例化配置对象，供模块其它位置直接导入使用
+settings = Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,26 @@
+from collections.abc import Iterator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from .config import settings
+
+
+# 依据配置构建数据库引擎；当使用 SQLite 时需关闭线程检查以便在 FastAPI 中复用连接
+engine = create_engine(
+    settings.database_url,
+    connect_args={"check_same_thread": False} if settings.database_url.startswith("sqlite") else {},
+)
+
+
+def init_db() -> None:
+    """根据 SQLModel 元数据自动创建数据表。"""
+
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Iterator[Session]:
+    """提供数据库会话给 FastAPI 依赖注入使用。"""
+
+    # 使用上下文管理器保证请求结束后自动关闭会话，防止连接泄漏
+    with Session(engine) as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .api import api_router
+from .config import settings
+from .database import init_db
+
+
+def create_application() -> FastAPI:
+    """应用工厂函数，供测试与实际部署复用。"""
+
+    # 以配置中的标题初始化 FastAPI 实例，便于前端或文档展示
+    app = FastAPI(title=settings.app_name)
+
+    # 配置 CORS，确保前端开发和多端访问时接口可被跨域调用
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.on_event("startup")
+    def on_startup() -> None:
+        """服务启动时自动建表，避免首次运行报错。"""
+
+        init_db()
+
+    @app.get("/health", tags=["health"])
+    def healthcheck() -> dict[str, str]:
+        """提供简单的健康检查，用于探活或监控。"""
+
+        return {"status": "ok"}
+
+    # 汇总注册所有子路由，保证模块化接口能被访问
+    app.include_router(api_router)
+
+    return app
+
+
+# 默认导出供 ASGI 服务器（如 uvicorn、gunicorn）直接加载
+app = create_application()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Optional
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Gender(str, Enum):
+    """患者性别枚举，限定可选值。"""
+
+    FEMALE = "female"
+    MALE = "male"
+    OTHER = "other"
+    UNKNOWN = "unknown"
+
+
+class AppointmentStatus(str, Enum):
+    """预约单状态枚举，描述就诊流程节点。"""
+
+    SCHEDULED = "scheduled"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class TimestampedModel(SQLModel):
+    """为模型增加创建与更新时间字段的混入类。"""
+
+    # 使用 UTC 时间戳记录，便于服务之间同步
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class DepartmentBase(SQLModel):
+    name: str = Field(index=True, max_length=200)
+    description: Optional[str] = Field(default=None, max_length=500)
+
+
+class Department(DepartmentBase, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    # 反向关联医生列表，便于一次性加载同科室医生信息
+    doctors: list["Doctor"] = Relationship(back_populates="department")
+
+
+class DepartmentRead(DepartmentBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class DepartmentCreate(DepartmentBase):
+    pass
+
+
+class PatientBase(SQLModel):
+    full_name: str = Field(max_length=200)
+    gender: Gender = Field(default=Gender.UNKNOWN)
+    birth_date: Optional[date] = None
+    phone: Optional[str] = Field(default=None, max_length=32)
+    id_card: Optional[str] = Field(default=None, max_length=64)
+    address: Optional[str] = Field(default=None, max_length=500)
+
+
+class Patient(TimestampedModel, PatientBase, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    # 维护患者下的所有预约记录
+    appointments: list["Appointment"] = Relationship(back_populates="patient")
+
+
+class PatientRead(PatientBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class PatientCreate(PatientBase):
+    pass
+
+
+class PatientUpdate(SQLModel):
+    full_name: Optional[str] = None
+    gender: Optional[Gender] = None
+    birth_date: Optional[date] = None
+    phone: Optional[str] = None
+    id_card: Optional[str] = None
+    address: Optional[str] = None
+
+
+class DoctorBase(SQLModel):
+    full_name: str = Field(max_length=200)
+    title: Optional[str] = Field(default=None, max_length=120)
+    department_id: Optional[int] = Field(default=None, foreign_key="department.id")
+    specialty: Optional[str] = Field(default=None, max_length=200)
+    phone: Optional[str] = Field(default=None, max_length=32)
+
+
+class Doctor(TimestampedModel, DoctorBase, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+
+    # 单个医生所属科室以及负责的预约
+    department: Optional[Department] = Relationship(back_populates="doctors")
+    appointments: list["Appointment"] = Relationship(back_populates="doctor")
+
+
+class DoctorRead(DoctorBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+    department: Optional[DepartmentRead] = None
+
+    class Config:
+        from_attributes = True
+
+
+class DoctorCreate(DoctorBase):
+    pass
+
+
+class DoctorUpdate(SQLModel):
+    full_name: Optional[str] = None
+    title: Optional[str] = None
+    department_id: Optional[int] = None
+    specialty: Optional[str] = None
+    phone: Optional[str] = None
+
+
+class AppointmentBase(SQLModel):
+    scheduled_time: datetime
+    reason: Optional[str] = Field(default=None, max_length=500)
+
+
+class Appointment(TimestampedModel, AppointmentBase, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    status: AppointmentStatus = Field(default=AppointmentStatus.SCHEDULED)
+    patient_id: int = Field(foreign_key="patient.id")
+    doctor_id: int = Field(foreign_key="doctor.id")
+
+    patient: Patient = Relationship(back_populates="appointments")
+    doctor: Doctor = Relationship(back_populates="appointments")
+
+
+class AppointmentRead(AppointmentBase):
+    id: int
+    status: AppointmentStatus
+    patient: PatientRead
+    doctor: DoctorRead
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class AppointmentCreate(AppointmentBase):
+    patient_id: int
+    doctor_id: int
+
+
+class AppointmentUpdate(SQLModel):
+    scheduled_time: Optional[datetime] = None
+    reason: Optional[str] = None
+    status: Optional[AppointmentStatus] = None
+    doctor_id: Optional[int] = None
+
+
+class DashboardSummary(SQLModel):
+    total_patients: int
+    total_doctors: int
+    appointments_today: int
+    upcoming_appointments: int
+    active_departments: int

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+sqlmodel==0.0.14
+pydantic==2.6.4

--- a/docs/patient-registration.md
+++ b/docs/patient-registration.md
@@ -1,0 +1,111 @@
+# 患者建档教程
+
+本文以“患者建档”为例，演示 LiteHIS 框架的端到端使用方式：从启动后端与前端，到调用 API、新增患者、在界面确认结果。完成本教程后，你可以轻松拓展其他业务流程，例如医生维护、门诊预约等。
+
+## 1. 环境准备
+
+在继续之前，请确认已按照《readme.md》中的“快速上手”步骤完成以下准备：
+
+- 后端服务（FastAPI）在 `http://localhost:8000` 运行；
+- 前端驾驶舱（Vite Dev Server）在 `http://localhost:5173` 运行；
+- 本地已创建默认的 `litehis.db` 数据库文件，或者你已经配置了自定义 `DATABASE_URL`。
+
+如果还未启动，请参考 `readme.md` 的详细说明。后续命令默认在 macOS/Linux 终端运行，Windows PowerShell 需要适度调整（如去掉 `\` 换行符）。
+
+## 2. 通过 API 创建患者
+
+LiteHIS 后端暴露 RESTful 接口，患者建档的入口为 `POST /patients/`。可以使用 `curl`、HTTPie 或 Swagger UI 进行调试。
+
+### 2.1 使用 curl 发起请求
+
+```bash
+curl -X POST "http://localhost:8000/patients/" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "full_name": "张小雅",
+    "gender": "female",
+    "birth_date": "1996-09-12",
+    "phone": "13800001234",
+    "id_card": "441900199609120321",
+    "address": "广东省广州市天河区健康路 8 号"
+  }'
+```
+
+请求体字段说明：
+
+| 字段 | 说明 | 是否必填 |
+| ---- | ---- | -------- |
+| `full_name` | 患者姓名 | ✅ |
+| `gender` | 性别，可选 `female`、`male`、`other`、`unknown` | ✅ |
+| `birth_date` | 出生日期（YYYY-MM-DD） | 可选 |
+| `phone` | 联系电话 | 可选 |
+| `id_card` | 身份证或就诊卡号 | 可选 |
+| `address` | 常住地址 | 可选 |
+
+响应示例：
+
+```json
+{
+  "id": 1,
+  "full_name": "张小雅",
+  "gender": "female",
+  "birth_date": "1996-09-12",
+  "phone": "13800001234",
+  "id_card": "441900199609120321",
+  "address": "广东省广州市天河区健康路 8 号",
+  "created_at": "2024-03-08T06:30:41.507507",
+  "updated_at": "2024-03-08T06:30:41.507511"
+}
+```
+
+### 2.2 查看患者列表
+
+```bash
+curl "http://localhost:8000/patients/"
+```
+
+返回值为按创建时间倒序排列的患者数组。若需要根据编号定位特定患者，也可调用 `GET /patients/{id}`：
+
+```bash
+curl "http://localhost:8000/patients/1"
+```
+
+### 2.3 修改患者信息（可选）
+
+接口 `PATCH /patients/{id}` 支持局部字段更新，例如补充地址：
+
+```bash
+curl -X PATCH "http://localhost:8000/patients/1" \
+  -H "Content-Type: application/json" \
+  -d '{ "address": "广州市天河区住院部 5F" }'
+```
+
+## 3. 在前端驾驶舱完成患者建档
+
+前端的“登记新患者”卡片与后端接口保持一致，表单字段会自动转换成所需的 JSON。操作流程：
+
+1. 打开 <http://localhost:5173>；
+2. 在 “登记新患者” 卡片内填写姓名、性别、出生日期、联系电话等信息；
+3. 点击“保存患者”，页面会调用 `POST /patients/` 接口；
+4. 保存成功后，卡片下方会以通知提示，右下角的“最新登记患者”列表自动刷新。
+
+如果需要在移动设备或平板上测试，只需确保能访问运行前端的主机，并在 `.env` 中将 `VITE_API_BASE` 指向后端真实地址。
+
+## 4. 数据校验与排错建议
+
+- **查看数据库原始数据**：默认 SQLite 数据文件位于项目根目录，可用 `sqlite3 litehis.db` 或 TablePlus 等工具查看 `patient` 表。
+- **跨域/端口问题**：若前端运行在非默认端口，请在 `backend/.env` 中设置 `CORS_ORIGINS=["http://your-host:port"]` 并重启后端。
+- **常见 HTTP 错误**：
+  - `422 Unprocessable Entity`：请求体字段缺失或格式不正确，请参考上方字段说明。
+  - `404 Not Found`：访问了不存在的患者编号，请确认 ID 或重新创建数据。
+- **批量导入建议**：可编写脚本读取 Excel/CSV，通过调用 `POST /patients/` 批量导入；若需要更高性能，可扩展批量插入接口或引入异步任务队列。
+
+## 5. 下一步
+
+完成患者建档后，可继续探索以下能力：
+
+- 调用 `POST /departments/`、`POST /doctors/` 维护科室与医生档案；
+- 在前端“安排门诊预约”卡片中选择患者和医生，创建 `POST /appointments/` 记录；
+- 基于现有模型扩展字段，例如增加患者既往史、联系方式标签等。
+
+欢迎根据医院实际流程自定义字段和界面，LiteHIS 的代码结构与配置都已为二次开发准备就绪。

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# API 基础地址
+VITE_API_BASE=http://localhost:8000

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LiteHIS 门诊驾驶舱</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "litehis-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "vue": "^3.4.15"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.4",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.4"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,653 @@
+<template>
+  <div class="app-shell">
+    <header class="topbar">
+      <div class="topbar__brand">
+        <span class="topbar__logo">LiteHIS</span>
+        <span class="topbar__subtitle">LiteHIS 门诊驾驶舱</span>
+      </div>
+      <div class="topbar__meta">
+        <span class="topbar__meta-item">今日概览</span>
+        <span class="topbar__meta-item">{{ now }}</span>
+      </div>
+    </header>
+
+    <main class="content">
+      <section class="summary-grid">
+        <article
+          v-for="card in summaryCards"
+          :key="card.label"
+          class="summary-card"
+          :style="{ '--accent': card.accent }"
+        >
+          <p class="summary-card__label">{{ card.label }}</p>
+          <p class="summary-card__value">{{ card.value }}</p>
+        </article>
+      </section>
+
+      <section class="grid">
+        <SectionCard title="登记新患者" subtitle="采集患者基础信息">
+          <form class="form-grid" @submit.prevent="handleCreatePatient">
+            <label>
+              姓名
+              <input v-model="patientForm.full_name" placeholder="例如：张小雅" required />
+            </label>
+            <label>
+              性别
+              <select v-model="patientForm.gender">
+                <option value="female">女</option>
+                <option value="male">男</option>
+                <option value="other">其他</option>
+                <option value="unknown">未知</option>
+              </select>
+            </label>
+            <label>
+              出生日期
+              <input v-model="patientForm.birth_date" type="date" />
+            </label>
+            <label>
+              联系电话
+              <input v-model="patientForm.phone" placeholder="138xxxxxxx" />
+            </label>
+            <label class="form-grid__full">
+              联系地址
+              <input v-model="patientForm.address" placeholder="患者常住地址" />
+            </label>
+            <button class="button" type="submit">保存患者</button>
+          </form>
+        </SectionCard>
+
+        <SectionCard title="新增医生" subtitle="维护门诊出诊信息">
+          <form class="form-grid" @submit.prevent="handleCreateDoctor">
+            <label>
+              姓名
+              <input v-model="doctorForm.full_name" placeholder="例如：李主任" required />
+            </label>
+            <label>
+              职称
+              <input v-model="doctorForm.title" placeholder="主任医师" />
+            </label>
+            <label>
+              所属科室
+              <select v-model="doctorForm.department_id">
+                <option :value="null">未分配</option>
+                <option v-for="department in departments" :key="department.id" :value="department.id">
+                  {{ department.name }}
+                </option>
+              </select>
+            </label>
+            <label>
+              专长
+              <input v-model="doctorForm.specialty" placeholder="呼吸内科、儿童哮喘…" />
+            </label>
+            <label>
+              联系电话
+              <input v-model="doctorForm.phone" placeholder="132xxxxxxx" />
+            </label>
+            <button class="button" type="submit">保存医生</button>
+          </form>
+        </SectionCard>
+
+        <SectionCard title="安排门诊预约" subtitle="匹配医生排班和患者需求">
+          <form class="form-grid" @submit.prevent="handleCreateAppointment">
+            <label>
+              患者
+              <select v-model.number="appointmentForm.patient_id" required>
+                <option value="" disabled>请选择患者</option>
+                <option v-for="patient in patients" :key="patient.id" :value="patient.id">
+                  {{ patient.full_name }}
+                </option>
+              </select>
+            </label>
+            <label>
+              医生
+              <select v-model.number="appointmentForm.doctor_id" required>
+                <option value="" disabled>请选择医生</option>
+                <option v-for="doctor in doctors" :key="doctor.id" :value="doctor.id">
+                  {{ doctor.full_name }}
+                </option>
+              </select>
+            </label>
+            <label>
+              预约时间
+              <input v-model="appointmentForm.scheduled_time" type="datetime-local" required />
+            </label>
+            <label class="form-grid__full">
+              就诊事由
+              <input v-model="appointmentForm.reason" placeholder="症状或备注信息" />
+            </label>
+            <button class="button" type="submit">创建预约</button>
+          </form>
+        </SectionCard>
+
+        <SectionCard title="新增科室" subtitle="为医生归属科室">
+          <form class="form-grid" @submit.prevent="handleCreateDepartment">
+            <label>
+              科室名称
+              <input v-model="departmentForm.name" placeholder="例如：呼吸内科" required />
+            </label>
+            <label class="form-grid__full">
+              科室简介
+              <input v-model="departmentForm.description" placeholder="科室诊疗范围" />
+            </label>
+            <button class="button" type="submit">保存科室</button>
+          </form>
+        </SectionCard>
+      </section>
+
+      <section class="grid grid--wide">
+        <SectionCard title="最新登记患者" subtitle="展示最近 10 条记录">
+          <ul class="list">
+            <li v-for="patient in patients" :key="patient.id" class="list__item">
+              <div>
+                <p class="list__title">{{ patient.full_name }}</p>
+                <p class="list__subtitle">
+                  {{ formatDate(patient.created_at) }} · {{ genderMap[patient.gender] || "未知" }}
+                </p>
+              </div>
+              <span class="list__tag">#{{ patient.id }}</span>
+            </li>
+            <li v-if="!patients.length" class="list__item list__item--empty">暂无患者数据</li>
+          </ul>
+        </SectionCard>
+
+        <SectionCard title="即将到诊预约" subtitle="按照时间排序">
+          <ul class="list">
+            <li v-for="appointment in upcomingAppointments" :key="appointment.id" class="list__item">
+              <div>
+                <p class="list__title">{{ appointment.patient.full_name }}</p>
+                <p class="list__subtitle">
+                  {{ formatDateTime(appointment.scheduled_time) }} · {{ appointment.doctor.full_name }}
+                </p>
+              </div>
+              <span class="status-pill" :data-status="appointment.status">{{ statusMap[appointment.status] }}</span>
+            </li>
+            <li v-if="!upcomingAppointments.length" class="list__item list__item--empty">暂无预约信息</li>
+          </ul>
+        </SectionCard>
+      </section>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from "vue";
+import { apiClient, type AppointmentPayload, type DoctorPayload, type PatientPayload } from "./api";
+import SectionCard from "./components/SectionCard.vue";
+
+// -------------------- 类型定义 --------------------
+type Gender = "female" | "male" | "other" | "unknown";
+
+type AppointmentStatus = "scheduled" | "completed" | "cancelled";
+
+interface Patient {
+  id: number;
+  full_name: string;
+  gender: Gender;
+  birth_date?: string | null;
+  phone?: string | null;
+  address?: string | null;
+  created_at: string;
+}
+
+interface Department {
+  id: number;
+  name: string;
+  description?: string | null;
+}
+
+interface Doctor {
+  id: number;
+  full_name: string;
+  title?: string | null;
+  specialty?: string | null;
+  phone?: string | null;
+  department?: Department | null;
+}
+
+interface Appointment {
+  id: number;
+  scheduled_time: string;
+  status: AppointmentStatus;
+  reason?: string | null;
+  patient: Patient;
+  doctor: Doctor;
+  created_at: string;
+}
+
+interface Summary {
+  total_patients: number;
+  total_doctors: number;
+  appointments_today: number;
+  upcoming_appointments: number;
+  active_departments: number;
+}
+
+// -------------------- 全局状态 --------------------
+const now = new Intl.DateTimeFormat("zh-CN", {
+  dateStyle: "medium",
+  timeStyle: "short",
+}).format(new Date());
+
+// 仪表盘汇总数据，配合卡片展示
+const summary = ref<Summary | null>(null);
+// 列表数据缓存，避免重复请求
+const patients = ref<Patient[]>([]);
+const doctors = ref<Doctor[]>([]);
+const departments = ref<Department[]>([]);
+const appointments = ref<Appointment[]>([]);
+
+// 字段映射，提升界面可读性
+const genderMap: Record<Gender, string> = {
+  female: "女",
+  male: "男",
+  other: "其他",
+  unknown: "未知",
+};
+
+const statusMap: Record<AppointmentStatus, string> = {
+  scheduled: "待就诊",
+  completed: "已完成",
+  cancelled: "已取消",
+};
+
+// -------------------- 表单状态 --------------------
+const patientForm = reactive<PatientPayload>({
+  full_name: "",
+  gender: "female",
+  birth_date: "",
+  phone: "",
+  id_card: "",
+  address: "",
+});
+
+const doctorForm = reactive<DoctorPayload>({
+  full_name: "",
+  title: "",
+  department_id: null,
+  specialty: "",
+  phone: "",
+});
+
+const appointmentForm = reactive<AppointmentPayload>({
+  patient_id: 0,
+  doctor_id: 0,
+  scheduled_time: "",
+  reason: "",
+});
+
+const departmentForm = reactive({
+  name: "",
+  description: "",
+});
+
+// 统计卡片配置，随数据变化自动刷新
+const summaryCards = computed(() => [
+  {
+    label: "患者总数",
+    value: summary.value?.total_patients ?? 0,
+    accent: "#6366f1",
+  },
+  {
+    label: "医生总数",
+    value: summary.value?.total_doctors ?? 0,
+    accent: "#22c55e",
+  },
+  {
+    label: "今日预约",
+    value: summary.value?.appointments_today ?? 0,
+    accent: "#f97316",
+  },
+  {
+    label: "待诊队列",
+    value: summary.value?.upcoming_appointments ?? 0,
+    accent: "#0ea5e9",
+  },
+]);
+
+// 仅展示未来的预约，突出即将到诊的患者
+const upcomingAppointments = computed(() =>
+  appointments.value
+    .filter((item) => new Date(item.scheduled_time).getTime() >= Date.now())
+    .slice(0, 8)
+);
+
+// -------------------- 表单重置 --------------------
+function resetPatientForm() {
+  patientForm.full_name = "";
+  patientForm.gender = "female";
+  patientForm.birth_date = "";
+  patientForm.phone = "";
+  patientForm.id_card = "";
+  patientForm.address = "";
+}
+
+function resetDoctorForm() {
+  doctorForm.full_name = "";
+  doctorForm.title = "";
+  doctorForm.department_id = null;
+  doctorForm.specialty = "";
+  doctorForm.phone = "";
+}
+
+function resetAppointmentForm() {
+  appointmentForm.patient_id = 0;
+  appointmentForm.doctor_id = 0;
+  appointmentForm.scheduled_time = "";
+  appointmentForm.reason = "";
+}
+
+function resetDepartmentForm() {
+  departmentForm.name = "";
+  departmentForm.description = "";
+}
+
+// -------------------- 数据加载 --------------------
+async function loadSummary() {
+  const { data } = await apiClient.get<Summary>("/dashboard/summary");
+  summary.value = data;
+}
+
+async function loadPatients() {
+  const { data } = await apiClient.get<Patient[]>("/patients");
+  // 仅保留最新 10 条，便于概览
+  patients.value = data.slice(0, 10);
+}
+
+async function loadDoctors() {
+  const { data } = await apiClient.get<Doctor[]>("/doctors");
+  doctors.value = data;
+}
+
+async function loadAppointments() {
+  const { data } = await apiClient.get<Appointment[]>("/appointments", {
+    params: { status: "scheduled" },
+  });
+  appointments.value = data;
+}
+
+async function loadDepartments() {
+  const { data } = await apiClient.get<Department[]>("/departments");
+  departments.value = data;
+}
+
+// -------------------- 表单提交 --------------------
+async function handleCreatePatient() {
+  await apiClient.post("/patients", patientForm);
+  resetPatientForm();
+  await Promise.all([loadPatients(), loadSummary()]);
+}
+
+async function handleCreateDoctor() {
+  // Vue 的 select 返回 string，需转为数字或 null
+  const payload = { ...doctorForm, department_id: doctorForm.department_id ?? null };
+  await apiClient.post("/doctors", payload);
+  resetDoctorForm();
+  await Promise.all([loadDoctors(), loadSummary()]);
+}
+
+async function handleCreateAppointment() {
+  await apiClient.post("/appointments", appointmentForm);
+  resetAppointmentForm();
+  await Promise.all([loadAppointments(), loadSummary()]);
+}
+
+async function handleCreateDepartment() {
+  await apiClient.post("/departments", departmentForm);
+  resetDepartmentForm();
+  await Promise.all([loadDepartments(), loadSummary()]);
+}
+
+// -------------------- 辅助工具 --------------------
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("zh-CN", { dateStyle: "medium", timeStyle: "short" }).format(
+    new Date(value)
+  );
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("zh-CN", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+// -------------------- 生命周期 --------------------
+onMounted(async () => {
+  await Promise.all([loadSummary(), loadDepartments(), loadDoctors(), loadPatients(), loadAppointments()]);
+});
+</script>
+
+<style scoped>
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 1.5rem 2rem 3rem;
+  gap: 2rem;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: radial-gradient(circle at top left, #4f46e5, #1e3a8a);
+  color: #ffffff;
+  box-shadow: 0 20px 40px rgba(51, 65, 255, 0.2);
+}
+
+.topbar__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.topbar__logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.topbar__subtitle {
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.topbar__meta {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.topbar__meta-item {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 12px 30px rgba(59, 130, 246, 0.16);
+  border-top: 6px solid var(--accent, #6366f1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.summary-card__label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.summary-card__value {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.grid--wide {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.form-grid input,
+.form-grid select {
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.95);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-grid input:focus,
+.form-grid select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+.form-grid__full {
+  grid-column: 1 / -1;
+}
+
+.button {
+  grid-column: 1 / -1;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  color: white;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.3);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  gap: 0.75rem;
+}
+
+.list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.list__item--empty {
+  justify-content: center;
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.list__title {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.list__subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.list__tag {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.15);
+  color: #4338ca;
+  font-size: 0.8rem;
+}
+
+.status-pill {
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-pill[data-status="scheduled"] {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.status-pill[data-status="completed"] {
+  background: rgba(34, 197, 94, 0.12);
+  color: #15803d;
+}
+
+.status-pill[data-status="cancelled"] {
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+}
+
+@media (max-width: 768px) {
+  .app-shell {
+    padding: 1.25rem 1rem 2rem;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+
+// 统一封装 Axios 客户端，读取环境变量中的后端地址
+const apiBaseUrl = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+
+export const apiClient = axios.create({
+  baseURL: apiBaseUrl,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// ----------- 以下为前端提交表单时的请求体类型 -----------
+export interface PatientPayload {
+  full_name: string;
+  gender?: string;
+  birth_date?: string | null;
+  phone?: string | null;
+  id_card?: string | null;
+  address?: string | null;
+}
+
+export interface DoctorPayload {
+  full_name: string;
+  title?: string | null;
+  department_id?: number | null;
+  specialty?: string | null;
+  phone?: string | null;
+}
+
+export interface AppointmentPayload {
+  patient_id: number;
+  doctor_id: number;
+  scheduled_time: string;
+  reason?: string | null;
+}

--- a/frontend/src/components/SectionCard.vue
+++ b/frontend/src/components/SectionCard.vue
@@ -1,0 +1,62 @@
+<template>
+  <section class="section-card">
+    <header class="section-card__header">
+      <div>
+        <h2>{{ title }}</h2>
+        <p v-if="subtitle" class="section-card__subtitle">{{ subtitle }}</p>
+      </div>
+      <slot name="actions"></slot>
+    </header>
+    <div class="section-card__body">
+      <slot></slot>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  title: string;
+  subtitle?: string;
+}
+
+defineProps<Props>();
+</script>
+
+<style scoped>
+.section-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(50, 76, 140, 0.12);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  backdrop-filter: blur(6px);
+}
+
+.section-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-card__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #14213d;
+}
+
+.section-card__subtitle {
+  margin: 0;
+  color: #4f5d75;
+  font-size: 0.875rem;
+}
+
+.section-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+</style>

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import "./style.css";
+
+createApp(App).mount("#app");

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,0 +1,20 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Noto Sans SC", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f5f7fb;
+  color: #1a1b1f;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #fdfdff 0%, #eef2ff 100%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173,
+  },
+});

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,156 @@
-hello 
+# LiteHIS
+
+LiteHIS 是面向中小型医院的轻量化医院信息系统（HIS）脚手架，采用 B/S 架构并兼顾信创生态兼容性。仓库包含 FastAPI + SQLModel 构建的后端服务以及 Vue 3 + Vite 打造的前端驾驶舱，可快速完成患者、医生、科室、预约等基础业务的录入与展示。
+
+## 架构总览
+
+```
+┌──────────┐      RESTful API      ┌──────────────┐
+│  Vue 3   │  <----------------->  │   FastAPI    │
+│  Vite    │                       │  SQLModel    │
+└──────────┘                       └──────────────┘
+      │                                   │
+      │                                   ├── SQLite（默认，可替换 openGauss、PostgreSQL 等）
+      │                                   └── Redis / MQ 等可按需扩展
+```
+
+- **后端**：FastAPI 提供患者、医生、科室、预约、仪表盘等模块化接口，SQLModel 映射数据库实体，默认使用 SQLite，可替换为国产数据库。
+- **前端**：Vue 3 + TypeScript + Vite 构建的单页应用，内置轻量化 UI，提供四大表单与概览面板，支持自定义 API 基地址。
+
+## 快速上手
+
+### 1. 启动后端服务
+
+1. 切换到 `backend/` 目录并创建虚拟环境：
+
+   ```bash
+   cd backend
+   python -m venv .venv
+   source .venv/bin/activate  # Windows 使用 .venv\\Scripts\\activate
+   ```
+
+2. 安装依赖并启动 FastAPI：
+
+   ```bash
+   pip install -r requirements.txt
+   uvicorn app.main:app --reload --port 8000
+   ```
+
+   首次运行会自动在项目根目录生成 `litehis.db` SQLite 文件并完成建表。若医院上线环境要求国产数据库，可在 `backend/.env` 中覆盖 `DATABASE_URL`，或直接修改 `app/config.py` 中的默认值以连接 openGauss、PostgreSQL 等实例。
+
+3. 访问 <http://localhost:8000/docs> 打开 Swagger UI，可直接在线调用所有 API 并查看请求/响应模型。
+
+### 2. 启动前端驾驶舱
+
+1. 切换到 `frontend/` 目录并准备环境：
+
+   ```bash
+   cd frontend
+   cp .env.example .env    # 如需自定义后端地址请修改 VITE_API_BASE
+   ```
+
+2. 安装依赖并启动开发服务器：
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+3. 在浏览器打开 <http://localhost:5173>，即可体验驾驶舱界面。页面加载后会自动调用后端接口刷新统计卡片、列表和表单选项。
+
+> 若遇到 npm 源无法访问，可临时执行 `npm config set registry https://registry.npmmirror.com` 切换到国内镜像，再重新安装依赖。
+
+### 3. 日常开发小贴士
+
+- **数据库文件**：默认位于仓库根目录，可通过删除 `litehis.db` 让系统重新初始化空表；也可以在 `.env` 中配置到持久化路径。
+- **热重载**：后端使用 `uvicorn --reload`，前端 `npm run dev` 均支持热更新，无需手动重启。
+- **接口联调**：可借助 Swagger UI、Postman 或 `curl` 直接调用接口；前端 Axios 客户端统一封装在 `frontend/src/api.ts`，便于扩展鉴权、请求头等逻辑。
+
+## 示例：患者建档
+
+以下示例演示如何通过接口完成患者建档，并在前端驾驶舱中查看结果。
+
+### 步骤 1：调用后端接口创建患者
+
+在终端保持后端服务运行后，另开一个终端执行：
+
+```bash
+curl -X POST "http://localhost:8000/patients/" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "full_name": "张小雅",
+    "gender": "female",
+    "birth_date": "1996-09-12",
+    "phone": "13800001234",
+    "address": "广东省广州市天河区健康路 8 号"
+  }'
+```
+
+接口会返回新建患者的完整信息，包括系统生成的主键与时间戳：
+
+```json
+{
+  "id": 1,
+  "full_name": "张小雅",
+  "gender": "female",
+  "birth_date": "1996-09-12",
+  "phone": "13800001234",
+  "id_card": null,
+  "address": "广东省广州市天河区健康路 8 号",
+  "created_at": "2024-03-08T06:30:41.507507",
+  "updated_at": "2024-03-08T06:30:41.507511"
+}
+```
+
+### 步骤 2：验证患者已入库
+
+可以通过 `GET /patients/` 查看所有患者：
+
+```bash
+curl "http://localhost:8000/patients/"
+```
+
+或在 Swagger UI 中点击 `GET /patients/`，即可确认刚才的记录已经写入数据库。
+
+### 步骤 3：在前端驾驶舱查看
+
+保持前端服务运行并刷新页面，左下角的 “最新登记患者” 列表会出现 “张小雅” 的条目。若需要通过 UI 建档，只需在“登记新患者”表单填写同样的信息并点击“保存患者”，页面会弹出保存提示并自动刷新列表。
+
+更多建档、更新、搜索的细节可在《[患者建档教程](docs/patient-registration.md)》中查看。
+
+## 教程与延伸阅读
+
+- [患者建档教程](docs/patient-registration.md)：一步步完成患者建档、查询、修改，以及排错建议。
+- 后续可补充更多模块教程（如医生维护、门诊预约），欢迎在此目录新增文档并在此处汇总。
+
+## 目录结构
+
+```
+backend/
+  app/
+    api/           # FastAPI 路由（患者、医生、科室、预约、仪表盘）
+    config.py      # 应用配置
+    database.py    # 数据库初始化及会话依赖
+    main.py        # FastAPI 入口
+    models.py      # SQLModel 数据实体与 Pydantic 模型
+  requirements.txt
+frontend/
+  src/
+    components/    # Vue 复用组件
+    api.ts         # Axios 封装
+    App.vue        # 主界面
+    main.ts        # 应用入口
+    style.css      # 全局样式
+  package.json
+  vite.config.ts
+  tsconfig*.json
+.gitignore
+readme.md
+```
+
+## 下一步建议
+
+- 引入统一身份认证、RBAC 与操作审计。
+- 扩展药房、收费、检验等模块，打通第三方系统接口（医保、LIS、PACS）。
+- 增加自动化测试与 CI/CD，纳入性能压测脚本。
+


### PR DESCRIPTION
## Summary
- expand the README quick-start section with backend/frontend boot steps, troubleshooting tips, and a worked patient onboarding example
- add a dedicated "患者建档教程" document that walks through API calls, UI usage, and troubleshooting guidance
- replace institution-specific wording and add detailed Chinese annotations across backend services and the Vue cockpit

## Testing
- python -m compileall backend
- npm install *(fails: npm registry returned 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb69a9572c83308df4d06f6dc25e72